### PR TITLE
Add examples for projectriff/node-function-invoker

### DIFF
--- a/test-nodejs-nodeps/Dockerfile
+++ b/test-nodejs-nodeps/Dockerfile
@@ -1,0 +1,4 @@
+FROM projectriff/node-function-invoker:0.0.9-snapshot@sha256:77adb936cc46e47403ca71b6d70be70929a62c0b9bfc2da718097dace5046e68
+
+ENV FUNCTION_URI /functions/square.js
+COPY square.js ${FUNCTION_URI}

--- a/test-nodejs-nodeps/square.js
+++ b/test-nodejs-nodeps/square.js
@@ -1,0 +1,1 @@
+module.exports = x => x ** 2;

--- a/test-nodejs-nodeps/test.sh
+++ b/test-nodejs-nodeps/test.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+docker build -t riff-square .
+docker run --rm --name test-riff-square -d -p 8080:8080 -p 10382:10382 riff-square
+sleep 1
+docker logs test-riff-square
+
+VALUE="4"; EXPECT="16"
+RESULT=$(curl -v -X POST -H "Content-Type: text/plain" --data "$VALUE" http://localhost:8080/)
+
+docker kill test-riff-square
+
+echo "Square $VALUE = $RESULT"
+[ "$RESULT" -eq "$EXPECT" ]

--- a/test-nodejs-packagelock/.dockerignore
+++ b/test-nodejs-packagelock/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+test.sh

--- a/test-nodejs-packagelock/.gitignore
+++ b/test-nodejs-packagelock/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/test-nodejs-packagelock/Dockerfile
+++ b/test-nodejs-packagelock/Dockerfile
@@ -4,5 +4,5 @@ FROM projectriff/node-function-invoker:0.0.9-snapshot@sha256:77adb936cc46e47403c
 # {{ if .FileExists "package.json" -}}
 ENV FUNCTION_URI /functions/
 COPY . ${FUNCTION_URI}
-RUN (cd ${FUNCTION_URI} && npm install --production  --unsafe-perm)
+RUN (cd ${FUNCTION_URI} && npm ci)
 # {{- else -}}

--- a/test-nodejs-packagelock/Dockerfile
+++ b/test-nodejs-packagelock/Dockerfile
@@ -1,0 +1,8 @@
+FROM projectriff/node-function-invoker:0.0.9-snapshot@sha256:77adb936cc46e47403ca71b6d70be70929a62c0b9bfc2da718097dace5046e68
+
+# https://github.com/projectriff/node-function-invoker/blob/master/node-invoker.yaml
+# {{ if .FileExists "package.json" -}}
+ENV FUNCTION_URI /functions/
+COPY . ${FUNCTION_URI}
+RUN (cd ${FUNCTION_URI} && npm install --production  --unsafe-perm)
+# {{- else -}}

--- a/test-nodejs-packagelock/Dockerfile
+++ b/test-nodejs-packagelock/Dockerfile
@@ -3,6 +3,7 @@ FROM projectriff/node-function-invoker:0.0.9-snapshot@sha256:77adb936cc46e47403c
 # https://github.com/projectriff/node-function-invoker/blob/master/node-invoker.yaml
 # {{ if .FileExists "package.json" -}}
 ENV FUNCTION_URI /functions/
-COPY . ${FUNCTION_URI}
+COPY package*.json ${FUNCTION_URI}
 RUN (cd ${FUNCTION_URI} && npm ci)
+COPY . ${FUNCTION_URI}
 # {{- else -}}

--- a/test-nodejs-packagelock/aguid.js
+++ b/test-nodejs-packagelock/aguid.js
@@ -1,0 +1,3 @@
+const aguid = require('aguid');
+
+module.exports = x => aguid(x);

--- a/test-nodejs-packagelock/package-lock.json
+++ b/test-nodejs-packagelock/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "test-nodejs-packagelock",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "aguid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aguid/-/aguid-2.0.0.tgz",
+      "integrity": "sha1-ZLwmSHDe3w65xyvdtT5bMNMrwik=",
+      "requires": {
+        "uuid": "^3.0.1"
+      }
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    }
+  }
+}

--- a/test-nodejs-packagelock/package.json
+++ b/test-nodejs-packagelock/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "test-nodejs-packagelock",
+  "version": "1.0.0",
+  "description": "",
+  "main": "aguid.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "aguid": "2.0.0"
+  }
+}

--- a/test-nodejs-packagelock/test.sh
+++ b/test-nodejs-packagelock/test.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+docker build -t riff-aguid .
+docker run --rm --name test-riff-aguid -d -p 8080:8080 -p 10382:10382 riff-aguid
+sleep 1
+docker logs test-riff-aguid
+
+VALUE="Hello"; EXPECT="185f8db3-271f-45f5-8a6f-938b2e264306"
+RESULT=$(curl -v -X POST -H "Content-Type: text/plain" --data "$VALUE" http://localhost:8080/)
+
+docker kill test-riff-aguid
+
+echo "aguid $VALUE = $RESULT"
+[ "$RESULT" == "$EXPECT" ]


### PR DESCRIPTION
Turns out we might not need the riff cli for which this repo was originally created